### PR TITLE
Cast split address config to bool

### DIFF
--- a/src/ConfigProvider/CheckoutConfigProvider.php
+++ b/src/ConfigProvider/CheckoutConfigProvider.php
@@ -43,7 +43,7 @@ class CheckoutConfigProvider implements ConfigProviderInterface
                     self::CONFIG_PATH_AUTO_COMPLETE_API_KEY,
                     ScopeInterface::SCOPE_STORE
                 ),
-                'splitStreetFields' => $this->scopeConfig->getValue(
+                'splitStreetFields' => (bool)$this->scopeConfig->getValue(
                     self::CONFIG_PATH_AUTO_COMPLETE_SPLIT,
                     ScopeInterface::SCOPE_STORE
                 ),


### PR DESCRIPTION
`clean_checkout/auto_complete/split_street_fields` Will return a string containing `0` and is always true in javascript. Cast value to bool so the setting will be respected.

## Steps to reproduce
1. Enable address autocomplete.
2. Disable split address.