### PR TITLE
Added component restriction based on allowed countries

### DIFF
--- a/src/view/frontend/web/js/view/autocomplete.js
+++ b/src/view/frontend/web/js/view/autocomplete.js
@@ -35,6 +35,7 @@ define([
                                 autocomplete.addListener('place_changed', this.fillAddressFields);
                                 autocomplete.e = e.target;
                                 autocomplete.c = this;
+                                autocomplete.setComponentRestrictions({'country': this.getCountries(e.target)});
                                 this.autocomplete[e.target.id] = autocomplete;
                             }
                         }.bind(this));
@@ -107,6 +108,22 @@ define([
             }
             this.c.fillStreetFields(this.e, place);
             this.c.fillOtherFields(this.e, place);
+        },
+
+
+        getCountries: function(element) {
+            var form = $(element).closest('form');
+            var countries = [];
+
+            form.find("select[name='country_id'] option").each(function() {
+                var country = $(this).val();
+
+                if (country && (country !== 'delimiter')) {
+                    countries.push($(this).val());
+                }
+            });
+
+            return countries;
         }
     });
 });


### PR DESCRIPTION
I use the Clean Checkout module in a project. For that project I've received some feedback that it would be nice if the autocomplete would only suggest addresses for countries that are allowed. I wondered if that was possible and after some research it seemed quite easy.

I've added a component restriction for country to the autocomplete. The values are based on the options of the country select in the form.

Please let me know if I need to change or add anything. 
